### PR TITLE
fix: maintain 1.0 api compatability

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,14 +3,21 @@ var MD5 = require('md5.js')
 
 /* eslint-disable camelcase */
 function EVP_BytesToKey (password, salt, keyLen, ivLen) {
-  if (!Buffer.isBuffer(password)) password = Buffer.from(password, 'binary')
+  if (!Buffer.isBuffer(password)) {
+    password = Buffer.from(password, 'binary')
+  }
   if (salt) {
-    if (!Buffer.isBuffer(salt)) salt = Buffer.from(salt, 'binary')
-    if (salt.length !== 8) throw new RangeError('salt should be Buffer with 8 byte length')
+    if (!Buffer.isBuffer(salt)) {
+      salt = Buffer.from(salt, 'binary')
+    }
+    if (salt.length !== 8) {
+      throw new RangeError('salt should be Buffer with 8 byte length')
+    }
   }
 
+  keyLen = keyLen / 8
   var key = Buffer.alloc(keyLen)
-  var iv = Buffer.alloc(ivLen)
+  var iv = Buffer.alloc(ivLen || 0)
   var tmp = Buffer.alloc(0)
 
   while (keyLen > 0 || ivLen > 0) {

--- a/test/index.js
+++ b/test/index.js
@@ -12,7 +12,7 @@ var crypto = require('crypto')
 var test = require('tape')
 var EVP_BytesToKey = require('../')
 
-var keyLen = 32
+var keyLen = 256
 var ivLen = 16
 
 for (var i = 0; i < 1000; ++i) {
@@ -22,6 +22,7 @@ for (var i = 0; i < 1000; ++i) {
   test('password: ' + password.toString('base64') + ', salt: null', function (t) {
     var result = EVP_BytesToKey(password, null, keyLen, ivLen)
     var expected = OpenSSL_EVP_BytesToKey.md5_key32_iv16(null, password, 1)
+
     t.same(result, expected)
     t.end()
   })
@@ -29,6 +30,15 @@ for (var i = 0; i < 1000; ++i) {
   test('password: ' + password.toString('base64') + ', salt: ' + salt.toString('base64'), function (t) {
     var result = EVP_BytesToKey(password, salt, keyLen, ivLen)
     var expected = OpenSSL_EVP_BytesToKey.md5_key32_iv16(salt, password, 1)
+    t.same(result, expected)
+    t.end()
+  })
+
+  test('password: ' + password.toString('base64') + ', salt: ' + salt.toString('base64') + ', no iv', function (t) {
+    var result = EVP_BytesToKey(password, salt, keyLen, 0)
+    var expected = OpenSSL_EVP_BytesToKey.md5_key32_iv0(salt, password, 1)
+
+    console.log(result, expected)
     t.same(result, expected)
     t.end()
   })

--- a/test/main.cc
+++ b/test/main.cc
@@ -30,8 +30,36 @@ NAN_METHOD(md5_key32_iv16) {
   info.GetReturnValue().Set(obj);
 }
 
+NAN_METHOD(md5_key32_iv0) {
+  Nan::HandleScope scope;
+
+  const EVP_CIPHER* cipher = EVP_get_cipherbyname("aes-256-cbc");
+
+  const unsigned char* salt = NULL;
+  if (!info[0]->IsNull()) {
+    salt = (const unsigned char*) node::Buffer::Data(info[0].As<v8::Object>());
+  }
+
+  v8::Local<v8::Object> data_buffer = info[1].As<v8::Object>();
+  const unsigned char* data = (const unsigned char*) node::Buffer::Data(data_buffer);
+
+  const int count = info[3].As<v8::Integer>()->Value();
+  unsigned char key[32] = {0};
+
+  int key_len = EVP_BytesToKey(cipher, EVP_md5(), salt, data, node::Buffer::Length(data_buffer), count, key, NULL);
+  if (key_len != 32) {
+    return Nan::ThrowRangeError("invalid key length returned");
+  }
+
+  v8::Local<v8::Object> obj = Nan::New<v8::Object>();
+  obj->Set(Nan::New<v8::String>("key").ToLocalChecked(), Nan::CopyBuffer((const char*) key, 32).ToLocalChecked());
+  obj->Set(Nan::New<v8::String>("iv").ToLocalChecked(), Nan::CopyBuffer((const char*) NULL, 0).ToLocalChecked());
+  info.GetReturnValue().Set(obj);
+}
+
 NAN_MODULE_INIT(Init) {
   Nan::Export(target, "md5_key32_iv16", md5_key32_iv16);
+  Nan::Export(target, "md5_key32_iv0", md5_key32_iv0);
 }
 
 NODE_MODULE(OpenSSL_EVP_BytesToKey, Init)


### PR DESCRIPTION
- divide keyLen by 8, so 128 -> 16
- make ivLen optional, defaulting to 0

Fixes https://github.com/crypto-browserify/browserify-aes/issues/46